### PR TITLE
bugfix: Cast Uncaught Exceptions to Strings

### DIFF
--- a/src/testy.lua
+++ b/src/testy.lua
@@ -510,6 +510,7 @@ for _,t in ipairs( tests ) do
       fh:write( "# [ERROR] test function '", t.name, "' died:\n# ",
                 msg:gsub( "\n", "\n# " ), "\n" )
     else
+      msg = tostring(msg) -- msg may be an object
       fh:write( "[ERROR] test function '", t.name, "' died:\n ",
                 msg:gsub( "\n", "\n " ), "\n" )
     end


### PR DESCRIPTION
User-land code that uses exception objects instead of strings causes an error when they're thrown during a test.
Line 513 ends up trying to concat a table.

Just optimistically calling `tostring` can help debugging